### PR TITLE
Factor out PR and Assistant

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,20 @@
 import asyncio
 
+import ai.assistant
+import ai.prompt
 import config
-from app import App
+from app import App, get_pr, build_context
 
 
 def main():
     cfg = config.from_env()
-    app = App(cfg)
+    pr = get_pr(cfg.github)
+
+    context = build_context(pr)
+    builder = ai.prompt.Builder(context)
+    assistant = ai.assistant.Assistant(cfg.llm.model, builder)
+
+    app = App(pr, assistant, debug=cfg.debug)
 
     asyncio.run(app.run())
 


### PR DESCRIPTION
Resolves #25 
Use dependency injection to pass the PR and assistant to the app.

We are building the PR, context and assistant outside the app and then injecting them into it. It is more work at the entry point level but enables greater flexibility.